### PR TITLE
Add data errors to exported metric.

### DIFF
--- a/zfs-stats-exporter
+++ b/zfs-stats-exporter
@@ -32,9 +32,14 @@ def get_error_counts(
         m = re.match("^  pool: (.+)", line)
         if m:
             pool_name = m.groups(1)[0]
-            error_counts[pool_name] = {"read": 0, "write": 0, "cksum": 0}
+            error_counts[pool_name] = {"read": 0, "write": 0, "cksum": 0, "data_errors": 0}
             summing = 0
             continue
+
+        m = re.match("^errors: ([0-9]+) data errors", line)
+        if m:
+            data_errors, = m.groups()
+            error_counts[pool_name]["data_errors"] += int(data_errors)
 
         m = re.match("^\tNAME", line)
         if m:


### PR DESCRIPTION
This change parses the data errors metric from the zpool status output, e.g.:
```
$ zpool status
  pool: z
 state: ONLINE
status: One or more devices has experienced an error resulting in data
        corruption.  Applications may be affected.
action: Restore the file in question if possible.  Otherwise restore the
        entire pool from backup.
   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-8A
  scan: scrub in progress since Mon Jan  9 11:55:14 2023
        3.41T scanned at 3.06G/s, 483G issued at 433M/s, 6.37T total
        0B repaired, 7.39% done, 03:58:12 to go
config:

        NAME                                                  STATE     READ WRITE CKSUM
        z                                                     ONLINE       0     0     0
          raidz2-0                                            ONLINE       0     0     0
[...]
errors: List of errors unavailable: permission denied

errors: 9 data errors, use '-v' for a list
```
